### PR TITLE
fix(gantt): removed unused import

### DIFF
--- a/packages/gantt/src/gantt.module.ts
+++ b/packages/gantt/src/gantt.module.ts
@@ -24,7 +24,6 @@ import { NgxGanttTableColumnComponent } from './table/gantt-column.component';
 import { NgxGanttTableComponent } from './table/gantt-table.component';
 import { GanttScrollbarComponent } from './components/scrollbar/scrollbar.component';
 import { i18nLocaleProvides } from './i18n';
-import { setDefaultTimeZone } from 'ngx-gantt';
 
 @NgModule({
     imports: [


### PR DESCRIPTION
importing from `ngx-gantt` inside the `ngx-gantt` causes errors when using the package, and the import was unused anyway

closes #514