### PR TITLE
fix(gantt-upper): use getUnixTime instead of manually dividing

### DIFF
--- a/packages/gantt/src/gantt-upper.ts
+++ b/packages/gantt/src/gantt-upper.ts
@@ -32,7 +32,7 @@ import {
 } from './class';
 import { GanttView, GanttViewOptions } from './views/view';
 import { createViewFactory } from './views/factory';
-import { GanttDate } from './utils/date';
+import { GanttDate, getUnixTime } from './utils/date';
 import { uniqBy, flatten, recursiveItems, getFlatItems, Dictionary, keyBy } from './utils/helpers';
 import { GanttDragContainer } from './gantt-drag-container';
 import { GanttConfigService, GanttGlobalConfig, GanttStyleOptions, defaultConfig } from './gantt.config';
@@ -271,11 +271,11 @@ export abstract class GanttUpper implements OnChanges, OnInit, OnDestroy {
         if (!this.start || !this.end) {
             this.originItems.forEach((item) => {
                 if (item.start && !this.start) {
-                    const itemStart = item.start instanceof Date ? item.start.getTime() / 1000 : item.start;
+                    const itemStart = item.start instanceof Date ? getUnixTime(item.start) : item.start;
                     start = start ? Math.min(start, itemStart) : itemStart;
                 }
                 if (item.end && !this.end) {
-                    const itemEnd = item.start instanceof Date ? item.start.getTime() / 1000 : item.start;
+                    const itemEnd = item.start instanceof Date ? getUnixTime(item.start) : item.start;
                     end = end ? Math.max(end, itemEnd) : itemEnd;
                 }
             });


### PR DESCRIPTION
This fixes an issue where GanttDate constructs an invalid date (1970)
The validation check at https://github.com/worktile/ngx-gantt/blob/master/packages/gantt/src/utils/date.ts#L101 expects a number/string value to be less than 13, and when dividing by 1000 the decimal part is retained which breaks the format, diving alone isn't sufficient and a truncation operation is needed, so we are using `getUnixTime` that handles [truncation](https://github.com/date-fns/date-fns/blob/main/src/getUnixTime/index.ts#L22 ) for us.

Steps to reproduce:
`const date = new Date('2025-02-24T13:00:57.123Z');`
`const unix = today.getTime() / 1000;` -> gives `1740402057.123` which is bigger than 13 and passing it to [TZdate](https://github.com/worktile/ngx-gantt/blob/master/packages/gantt/src/utils/date.ts#L104) will result in an invalid date `1970-01-01T00:29:00.402+00:00` because the decimal portion causes the month validation to fail.