### PR TITLE
fix(calendar-grid): track by x-axis and migrate to the built-in control flow

### DIFF
--- a/packages/gantt/src/components/calendar/grid/calendar-grid.component.html
+++ b/packages/gantt/src/components/calendar/grid/calendar-grid.component.html
@@ -1,28 +1,34 @@
 <div class="gantt-calendar-today-overlay" [style.width.px]="view.width">
-  <span class="today-line" *ngIf="ganttUpper.showTodayLine"> </span>
+  @if (ganttUpper.showTodayLine) {
+  <span class="today-line"> </span>
+  }
 </div>
 
 <svg class="gantt-calendar-grid-main" [attr.width]="view.width" [attr.height]="ganttUpper.styles.headerHeight - 1">
   <g>
-    <g *ngIf="view.showTimeline">
+    @if (view.showTimeline) {
+    <g>
+      @for (point of view.secondaryDatePoints; track point.x) {
       <line
-        *ngFor="let point of view.secondaryDatePoints; let i = index; trackBy: trackBy"
-        [attr.x1]="(i + 1) * view.cellWidth"
-        [attr.x2]="(i + 1) * view.cellWidth"
+        [attr.x1]="($index + 1) * view.cellWidth"
+        [attr.x2]="($index + 1) * view.cellWidth"
         [attr.y1]="0"
         [attr.y2]="mainHeight"
         class="secondary-line"
       ></line>
+      }
     </g>
+    }
     <g>
+      @for (point of view.primaryDatePoints; track point.x) {
       <line
-        *ngFor="let point of view.primaryDatePoints; let i = index; trackBy: trackBy"
-        [attr.x1]="(i + 1) * view.primaryWidth"
-        [attr.x2]="(i + 1) * view.primaryWidth"
+        [attr.x1]="($index + 1) * view.primaryWidth"
+        [attr.x2]="($index + 1) * view.primaryWidth"
         [attr.y1]="0"
         [attr.y2]="mainHeight"
         class="primary-line"
       ></line>
+      }
     </g>
   </g>
 </svg>

--- a/packages/gantt/src/components/calendar/grid/calendar-grid.component.ts
+++ b/packages/gantt/src/components/calendar/grid/calendar-grid.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, HostBinding, OnChanges, SimpleChanges, OnDestroy, NgZone, Inject, ElementRef } from '@angular/core';
-import { GanttDatePoint } from '../../../class/date-point';
 import { Subject, merge } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 
@@ -8,15 +7,13 @@ import { isNumber } from '../../../utils/helpers';
 import { GANTT_UPPER_TOKEN, GanttUpper } from '../../../gantt-upper';
 import { GanttViewType } from './../../../class/view-type';
 import { todayBorderRadius } from '../../../gantt.styles';
-import { NgIf, NgFor } from '@angular/common';
 
 const mainHeight = 5000;
 
 @Component({
     selector: 'gantt-calendar-grid',
     templateUrl: './calendar-grid.component.html',
-    standalone: true,
-    imports: [NgIf, NgFor]
+    standalone: true
 })
 export class GanttCalendarGridComponent implements OnInit, OnDestroy {
     get view() {
@@ -62,10 +59,6 @@ export class GanttCalendarGridComponent implements OnInit, OnDestroy {
                     this.setTodayPoint();
                 });
         });
-    }
-
-    trackBy(point: GanttDatePoint, index: number) {
-        return point.text || index;
     }
 
     ngOnDestroy() {

--- a/packages/gantt/src/components/calendar/header/calendar-header.component.html
+++ b/packages/gantt/src/components/calendar/header/calendar-header.component.html
@@ -3,39 +3,40 @@
 </div>
 <svg [attr.width]="view.width" [attr.height]="ganttUpper.styles.headerHeight">
   <g>
+    @for (point of view.primaryDatePoints; track point.x) {
     <text
       class="primary-text"
       [ngStyle]="point.style"
       [class.today]="point.additions?.isToday"
       [class.weekend]="point.additions?.isWeekend"
-      *ngFor="let point of view.primaryDatePoints; trackBy: trackBy"
       [attr.x]="point.x"
       [attr.y]="point.y"
     >
       {{ point.text }}
     </text>
-    <ng-container *ngFor="let point of view.secondaryDatePoints; trackBy: trackBy">
-      <text
-        class="secondary-text"
-        [ngStyle]="point.style"
-        [class.today]="point.additions?.isToday"
-        [class.weekend]="point.additions?.isWeekend"
-        [attr.x]="point.x"
-        [attr.y]="point.y"
-      >
-        {{ point.text }}
-      </text>
-    </ng-container>
+    } @for (point of view.secondaryDatePoints; track point.x) {
+    <text
+      class="secondary-text"
+      [ngStyle]="point.style"
+      [class.today]="point.additions?.isToday"
+      [class.weekend]="point.additions?.isWeekend"
+      [attr.x]="point.x"
+      [attr.y]="point.y"
+    >
+      {{ point.text }}
+    </text>
+    }
 
     <g>
+      @for (point of view.primaryDatePoints; track point.x) {
       <line
-        *ngFor="let point of view.primaryDatePoints; let i = index; trackBy: trackBy"
-        [attr.x1]="(i + 1) * view.primaryWidth"
-        [attr.x2]="(i + 1) * view.primaryWidth"
+        [attr.x1]="($index + 1) * view.primaryWidth"
+        [attr.x2]="($index + 1) * view.primaryWidth"
         [attr.y1]="0"
         [attr.y2]="ganttUpper.styles.headerHeight"
         class="primary-line"
       ></line>
+      }
     </g>
 
     <g>

--- a/packages/gantt/src/components/calendar/header/calendar-header.component.ts
+++ b/packages/gantt/src/components/calendar/header/calendar-header.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, HostBinding, Inject, NgZone, ElementRef } from '@angular/core';
-import { GanttDatePoint } from '../../../class/date-point';
 import { todayHeight, todayWidth } from '../../../gantt.styles';
 import { GANTT_UPPER_TOKEN, GanttUpper } from '../../../gantt-upper';
 import { GanttViewType } from '../../../class';
@@ -7,13 +6,13 @@ import { take, takeUntil } from 'rxjs/operators';
 import { Subject, merge } from 'rxjs';
 import { GanttDate } from '../../../utils/date';
 import { isNumber } from '../../../utils/helpers';
-import { NgFor, NgStyle } from '@angular/common';
+import { NgStyle } from '@angular/common';
 
 @Component({
     selector: 'gantt-calendar-header',
     templateUrl: './calendar-header.component.html',
     standalone: true,
-    imports: [NgFor, NgStyle]
+    imports: [NgStyle]
 })
 export class GanttCalendarHeaderComponent implements OnInit {
     get view() {
@@ -63,9 +62,5 @@ export class GanttCalendarHeaderComponent implements OnInit {
         } else {
             todayEle.style.display = 'none';
         }
-    }
-
-    trackBy(point: GanttDatePoint, index: number) {
-        return point.text || index;
     }
 }


### PR DESCRIPTION
The parameters order was flipped (index should first and item second), ~~this change fixes the order~~ this change tracks using the x-axis since it is the most unique thing in date points array, this also migrates to the new control flow