### PR TITLE
fix: gantt root component reference from public api

### DIFF
--- a/packages/gantt/src/components/main/gantt-main.component.ts
+++ b/packages/gantt/src/components/main/gantt-main.component.ts
@@ -7,7 +7,7 @@ import { NgxGanttBarComponent } from '../bar/bar.component';
 import { NgxGanttRangeComponent } from '../range/range.component';
 import { NgFor, NgIf, NgClass, NgTemplateOutlet } from '@angular/common';
 import { GanttLinksComponent } from '../links/links.component';
-import { NgxGanttRootComponent } from 'ngx-gantt';
+import { NgxGanttRootComponent } from './../../root.component';
 import { GanttIconComponent } from '../icon/icon.component';
 import { GanttDomService } from '../../gantt-dom.service';
 import { combineLatest, from, Subject, take, takeUntil } from 'rxjs';


### PR DESCRIPTION
closes: https://github.com/worktile/ngx-gantt/issues/520

![Screenshot 2025-03-09 at 16 40 41](https://github.com/user-attachments/assets/8ed02287-e66d-4e5c-8fd9-5e7b80e76456)
