### PR TITLE
fix: notify about collapsed / expanded groups

### DIFF
--- a/packages/gantt/src/gantt-upper.ts
+++ b/packages/gantt/src/gantt-upper.ts
@@ -316,8 +316,8 @@ export abstract class GanttUpper implements OnChanges, OnInit, OnDestroy {
     expandGroups(expanded: boolean) {
         this.groups.forEach((group) => {
             group.setExpand(expanded);
+            this.expandChange.emit(group);
         });
-        this.expandChange.next(null);
         this.cdr.detectChanges();
     }
 

--- a/packages/gantt/src/gantt.component.ts
+++ b/packages/gantt/src/gantt.component.ts
@@ -387,17 +387,17 @@ export class NgxGanttComponent extends GanttUpper implements OnInit, OnChanges, 
     override expandGroups(expanded: boolean) {
         this.groups.forEach((group) => {
             group.setExpand(expanded);
+            this.expandChange.emit(group);
         });
 
         this.afterExpand();
-        this.expandChange.next(null);
         this.cdr.detectChanges();
     }
 
     override expandGroup(group: GanttGroupInternal) {
         group.setExpand(!group.expanded);
         this.afterExpand();
-        this.expandChange.emit();
+        this.expandChange.emit(group);
         this.cdr.detectChanges();
     }
 


### PR DESCRIPTION
when collapsing or expanding groups, the expandChange is emitted with undefined, but I'd expect to get the group which was changed like I'd get the task when I collapsing / expanding it.
Additionally, I changed the behavior for collapsing all groups - in that case, we now trigger the expandChange for each of them.