### PR TITLE
expanded=false ignored for groups

### DIFF
--- a/packages/gantt/src/gantt-upper.ts
+++ b/packages/gantt/src/gantt-upper.ts
@@ -201,7 +201,7 @@ export abstract class GanttUpper implements OnChanges, OnInit, OnDestroy {
     }
 
     private setupGroups() {
-        const collapsedIds = this.groups.filter((group) => group.expanded === false).map((group) => group.id);
+        const collapsedIds = this.originGroups.filter((group) => group.expanded === false).map((group) => group.id);
         this.groupsMap = {};
         this.groups = [];
         this.originGroups.forEach((origin) => {


### PR DESCRIPTION
I tried to store which groups and tasks were collapsed and which expanded to restore this when a user visits a chart again and found that
group.expanded = false
was completely ignored. It took some time, but now I think I fixed it completely