### PR TITLE
fix: update expandChange event to emit groups instead of null

### DIFF
--- a/packages/gantt/src/gantt-upper.ts
+++ b/packages/gantt/src/gantt-upper.ts
@@ -123,7 +123,7 @@ export abstract class GanttUpper implements OnChanges, OnInit, OnDestroy {
 
     @Output() viewChange = new EventEmitter<GanttView>();
 
-    @Output() expandChange = new EventEmitter<GanttItemInternal | GanttGroupInternal>();
+    @Output() expandChange = new EventEmitter<GanttItemInternal | GanttGroupInternal | (GanttItemInternal | GanttGroupInternal)[]>();
 
     @ContentChild('bar', { static: true }) barTemplate: TemplateRef<any>;
 
@@ -317,7 +317,7 @@ export abstract class GanttUpper implements OnChanges, OnInit, OnDestroy {
         this.groups.forEach((group) => {
             group.setExpand(expanded);
         });
-        this.expandChange.next(null);
+        this.expandChange.emit(this.groups);
         this.cdr.detectChanges();
     }
 

--- a/packages/gantt/src/gantt.component.ts
+++ b/packages/gantt/src/gantt.component.ts
@@ -399,14 +399,14 @@ export class NgxGanttComponent extends GanttUpper implements OnInit, OnChanges, 
         });
 
         this.afterExpand();
-        this.expandChange.next(null);
+        this.expandChange.emit(this.groups);
         this.cdr.detectChanges();
     }
 
     override expandGroup(group: GanttGroupInternal) {
         group.setExpand(!group.expanded);
         this.afterExpand();
-        this.expandChange.emit();
+        this.expandChange.emit(group);
         this.cdr.detectChanges();
     }
 


### PR DESCRIPTION
This is a follow-up pull request to #559. As suggested there, I changed the expandChange EventEmitter to accept an array of groups (more precisely: an array of groups and tasks) to handle the special case of expanding/collapsing all groups at once.